### PR TITLE
Clean up options handling and sudo usage

### DIFF
--- a/zapgix/zapgix.sh
+++ b/zapgix/zapgix.sh
@@ -159,7 +159,7 @@ if [[ -n "$database" ]]; then
 fi
 
 cmd="psql -qAtX -U ${auth_user:-postgres} -f ${SQL%.sql}.sql"
-rval=`sudo su - ${UNIXUSER:-postgres} -c "${cmd} ${ARGS} 2>/dev/null"`
+rval=$(sudo -u ${UNIXUSER:-postgres} ${cmd} ${ARGS} 2>/dev/null)
 rcode="${?}"
 if [[ ${rcode} == 0 && ${TIMING} =~ ^(on|ON|1|true|TRUE)$ ]]; then
     rval=`echo -e "${rval}" | tail -n 1 |cut -d' ' -f2|sed 's/,/./'`

--- a/zapgix/zapgix.sh
+++ b/zapgix/zapgix.sh
@@ -37,6 +37,7 @@ usage() {
     echo ""
     echo "Options:"
     echo "  -a            Query arguments."
+    echo "  -d            Specify the database to connect to."
     echo "  -h            Displays this help message."
     echo "  -j            Jsonify output."
     echo "  -p            Specify the auth_pass to connect to the databases."
@@ -81,7 +82,7 @@ zabbix_not_support() {
 #################################################################################
 
 #################################################################################
-while getopts "s::a:sj:uphvt:" OPTION; do
+while getopts "s::a:d:sj:uphvt:" OPTION; do
     case ${OPTION} in
 	h)
 	    usage
@@ -118,6 +119,9 @@ while getopts "s::a:sj:uphvt:" OPTION; do
 	    param=${OPTARG//p=}
 	    [[ -n ${param} ]] && SQL_ARGS[${#SQL_ARGS[*]}]=${param}
 	    ;;
+        d)
+            database=${OPTARG}
+            ;;
 	u)
 	    auth_user=${OPTARG}
 	    ;;
@@ -149,6 +153,10 @@ for arg in ${SQL_ARGS[@]}; do
     fi
     let "count=count+1"
 done
+
+if [[ -n "$database" ]]; then
+    ARGS+="-d $database "
+fi
 
 cmd="psql -qAtX -U ${auth_user:-postgres} -f ${SQL%.sql}.sql"
 rval=`sudo su - ${UNIXUSER:-postgres} -c "${cmd} ${ARGS} 2>/dev/null"`

--- a/zapgix/zapgix.sh
+++ b/zapgix/zapgix.sh
@@ -82,10 +82,25 @@ zabbix_not_support() {
 #################################################################################
 
 #################################################################################
-while getopts "s::a:d:sj:uphvt:" OPTION; do
+while getopts ":a:d:hj:ps:t:uvU:" OPTION; do
     case ${OPTION} in
+	a)
+	    param=${OPTARG//p=}
+	    [[ -n ${param} ]] && SQL_ARGS[${#SQL_ARGS[*]}]=${param}
+	    ;;
+        d)
+            database=${OPTARG}
+            ;;
 	h)
 	    usage
+	    ;;
+        j)
+            JSON=1
+            IFS=":" JSON_ATTR=(${OPTARG})
+	    IFS="${IFS_DEFAULT}"
+            ;;
+	p)
+	    auth_pass=${OPTARG}
 	    ;;
 	s)
 	    IFS="." PSQL_VERSION=( `echo "${PSQL_VERSION}" | grep -Eo "[0-9]{1,}.*"` )
@@ -107,32 +122,17 @@ while getopts "s::a:d:sj:uphvt:" OPTION; do
 		zabbix_not_support
 	    fi
 	    ;;
-        j)
-            JSON=1
-            IFS=":" JSON_ATTR=(${OPTARG})
-	    IFS="${IFS_DEFAULT}"
-            ;;
 	t)
 	    TIMING=${OPTARG}
 	    ;;
-	a)
-	    param=${OPTARG//p=}
-	    [[ -n ${param} ]] && SQL_ARGS[${#SQL_ARGS[*]}]=${param}
-	    ;;
-        d)
-            database=${OPTARG}
-            ;;
 	u)
 	    auth_user=${OPTARG}
 	    ;;
-	p)
-	    auth_pass=${OPTARG}
+	v)
+	    version
 	    ;;
 	U)
 	    UNIXUSER=${OPTARG}
-	    ;;
-	v)
-	    version
 	    ;;
          \?)
             exit 1

--- a/zapgix/zapgix.sh
+++ b/zapgix/zapgix.sh
@@ -13,7 +13,7 @@ APP_NAME=$(basename $0)
 APP_DIR=$(dirname $0)
 APP_VER="1.0.1"
 APP_WEB="https://github.com/sergiotocalini"
-PSQL_VERSION=`psql -V 2>/dev/null`
+PSQL_VERSION=$(psql -V 2>/dev/null)
 #
 #################################################################################
 
@@ -89,7 +89,7 @@ while getopts ":a:d:hj:ps:t:uvU:" OPTION; do
 	    [[ -n ${param} ]] && SQL_ARGS[${#SQL_ARGS[*]}]=${param}
 	    ;;
         d)
-            database=${OPTARG}
+	    ARGS+="-d ${OPTARG} "
             ;;
 	h)
 	    usage
@@ -153,10 +153,6 @@ for arg in ${SQL_ARGS[@]}; do
     fi
     let "count=count+1"
 done
-
-if [[ -n "$database" ]]; then
-    ARGS+="-d $database "
-fi
 
 cmd="psql -qAtX -U ${auth_user:-postgres} -f ${SQL%.sql}.sql"
 rval=$(sudo -u ${UNIXUSER:-postgres} ${cmd} ${ARGS} 2>/dev/null)


### PR DESCRIPTION
Hello,

This PR includes a few things I needed to fit into my system:

- Add a -d switch to zapgix so it is possible to specify the database to connect to ;
- Simplify the privilege escalation process by using only `sudo` instead of a `sudo` + `su` combo which generates more logs ;
- Sort the options in usage() and `getopts` invocation ;
- Add the U switch to `getopts` parameter, it was documented but not used ;
- Remove the second s in `getopt` parameter.